### PR TITLE
Remove clock hands flicker

### DIFF
--- a/clock.css
+++ b/clock.css
@@ -37,6 +37,7 @@ body {
 }
 
 .hand {
+  visibility:hidden;
   width:50%;
   height:6px;
   background:black;

--- a/clock.js
+++ b/clock.js
@@ -1,7 +1,7 @@
 const secondHand = document.querySelector('.second-hand');
 const minuteHand = document.querySelector('.minute-hand');
 const hourHand = document.querySelector('.hour-hand');
-const clockHand = document.querySelector('.hand');
+const clockHands = document.querySelectorAll('.hand');
 
 const moveHandCSS = (hand, timeDegree) => {
   hand.style.transform = `rotate(${timeDegree}deg)`;
@@ -20,6 +20,10 @@ const updateClock = (second, minute, hour) => {
   moveHandCSS(secondHand, degreeSecond);
   moveHandCSS(minuteHand, degreeMinute);
   moveHandCSS(hourHand, degreeHour);
+
+  clockHands.forEach((hand) => {
+    hand.style.visibility = 'visible';
+  });
 };
 
 const setTime = () => {
@@ -31,3 +35,4 @@ const setTime = () => {
 };
 
 setInterval(setTime, 1000);
+setTime();

--- a/clock.js
+++ b/clock.js
@@ -30,6 +30,4 @@ const setTime = () => {
   updateClock(second, minute, hour);
 };
 
-setInterval(() => {
-  getDegree(setTime());
-}, 1000);
+setInterval(setTime, 1000);


### PR DESCRIPTION
What
===
Hide the clock hands initially. Make them visible once the current
time is known, and update the time immediately on page load.

Why
===
The clock hands show in the midnight position on page load, then change
to the current time after one second when the time is set. Hiding them
initially removes the flicker and updating the time immediately on page
load has the hands display practically immediately.

![](https://jif.wtf/03.l0MYLGjgThBb8C556.gif)